### PR TITLE
Adding osversion and package name to the crashinfo

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,7 +3,7 @@
   <component name="EntryPointsManager">
     <entry_points version="2.0" />
   </component>
-  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="1.7" project-jdk-type="JavaSDK">
+  <component name="ProjectRootManager" version="2" languageLevel="JDK_1_6" assert-keyword="true" jdk-15="true" project-jdk-name="JDK" project-jdk-type="JavaSDK">
     <output url="file://$PROJECT_DIR$/build/classes" />
   </component>
   <component name="masterDetails">

--- a/mobile/mobile.iml
+++ b/mobile/mobile.iml
@@ -78,6 +78,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
+      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 20 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />

--- a/mobile/src/main/java/fr/nicolaspomepuy/androidwearcrashreport/mobile/CrashInfo.java
+++ b/mobile/src/main/java/fr/nicolaspomepuy/androidwearcrashreport/mobile/CrashInfo.java
@@ -12,6 +12,8 @@ public class CrashInfo {
     private String product;
     private final int versionCode;
     private final String versionName;
+    private final String osVersion;
+    private final String packageName;
 
 
     private CrashInfo(Builder builder) {
@@ -22,6 +24,8 @@ public class CrashInfo {
         this.product = builder.product;
         this.versionCode = builder.versionCode;
         this.versionName = builder.versionName;
+        this.osVersion = builder.osVersion;
+        this.packageName = builder.packageName;
     }
 
     public static class Builder {
@@ -32,6 +36,8 @@ public class CrashInfo {
         private String product;
         private String versionName;
         private int versionCode;
+        private String osVersion;
+        private String packageName;
 
         public Builder(Throwable throwable) {
             this.throwable = throwable;
@@ -64,6 +70,16 @@ public class CrashInfo {
 
         public Builder versionName(String version) {
             this.versionName = version;
+            return this;
+        }
+
+        public Builder osVersion(String osVersion) {
+            this.osVersion = osVersion;
+            return this;
+        }
+
+        public Builder packageName(String packageName) {
+            this.packageName = packageName;
             return this;
         }
 
@@ -100,6 +116,14 @@ public class CrashInfo {
 
     public String getVersionName() {
         return versionName;
+    }
+
+    public String getOsVersion() {
+        return osVersion;
+    }
+
+    public String getPackageName() {
+        return packageName;
     }
 
     @Override

--- a/mobile/src/main/java/fr/nicolaspomepuy/androidwearcrashreport/mobile/CrashReport.java
+++ b/mobile/src/main/java/fr/nicolaspomepuy/androidwearcrashreport/mobile/CrashReport.java
@@ -99,6 +99,8 @@ public class CrashReport implements DataApi.DataListener, GoogleApiClient.Connec
                                 .product(dataMapItem.getDataMap().getString("product"))
                                 .versionCode(dataMapItem.getDataMap().getInt("versionCode"))
                                 .versionName(dataMapItem.getDataMap().getString("versionName"))
+                                .osVersion(dataMapItem.getDataMap().getString("osVersion"))
+                                .packageName(dataMapItem.getDataMap().getString("packageName"))
                                 .build();
                         onCrashListener.onCrashReceived(currentCrashInfo);
                     }

--- a/wear/src/main/java/fr/nicolaspomepuy/androidwearcrashreport/wear/CrashReporter.java
+++ b/wear/src/main/java/fr/nicolaspomepuy/androidwearcrashreport/wear/CrashReporter.java
@@ -121,8 +121,9 @@ public class CrashReporter {
         PackageInfo pinfo;
         int versionCode = 0;
         String versionName = "";
+        String packageName = context.getPackageName();
         try {
-            pinfo = context.getPackageManager().getPackageInfo(context.getPackageName(), 0);
+            pinfo = context.getPackageManager().getPackageInfo(packageName, 0);
             versionCode = pinfo.versionCode;
             versionName = pinfo.versionName;
         } catch (PackageManager.NameNotFoundException e) {
@@ -139,6 +140,8 @@ public class CrashReporter {
         dataMap.getDataMap().putString("product", Build.PRODUCT);
         dataMap.getDataMap().putString("versionName", versionName);
         dataMap.getDataMap().putInt("versionCode", versionCode);
+        dataMap.getDataMap().putString("osVersion", Build.VERSION.RELEASE);
+        dataMap.getDataMap().putString("packageName", packageName);
         PutDataRequest request = dataMap.asPutDataRequest();
         PendingResult<DataApi.DataItemResult> pendingResult = Wearable.DataApi.putDataItem(getGoogleApiClient(context), request);
 

--- a/wear/wear.iml
+++ b/wear/wear.iml
@@ -17,7 +17,7 @@
         <option name="ALLOW_USER_CONFIGURATION" value="false" />
         <option name="MANIFEST_FILE_RELATIVE_PATH" value="/src/main/AndroidManifest.xml" />
         <option name="RES_FOLDER_RELATIVE_PATH" value="/src/main/res" />
-        <option name="RES_FOLDERS_RELATIVE_PATH" value="file://$MODULE_DIR$/src/main/res" />
+        <option name="RES_FOLDERS_RELATIVE_PATH" value="" />
         <option name="ASSETS_FOLDER_RELATIVE_PATH" value="/src/main/assets" />
         <option name="LIBRARY_PROJECT" value="true" />
       </configuration>
@@ -77,10 +77,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/res" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/rs" />
       <excludeFolder url="file://$MODULE_DIR$/build/intermediates/symbols" />
-      <excludeFolder url="file://$MODULE_DIR$/build/libs" />
       <excludeFolder url="file://$MODULE_DIR$/build/outputs" />
-      <excludeFolder url="file://$MODULE_DIR$/build/publications" />
-      <excludeFolder url="file://$MODULE_DIR$/build/tmp" />
     </content>
     <orderEntry type="jdk" jdkName="Android API 20 Platform" jdkType="Android SDK" />
     <orderEntry type="sourceFolder" forTests="false" />


### PR DESCRIPTION
This is just adding the os version and the package name in the crash info bean, as I think both of them are pretty useful (Though to be honest I can get the package name in the phone as it has to be the same) but I do need the osVersion.

Can you please merge this request and publish a new version in mvn?

Thanks!

BTW sorry i did not mean to commit the AS files, if you want I can create another pull request without them.
