### PR TITLE
Update Google Play Services Version to Fix Breaking Change

### DIFF
--- a/mobile/build.gradle
+++ b/mobile/build.gradle
@@ -28,7 +28,7 @@ android {
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
     compile 'com.android.support:appcompat-v7:20.0.0'
-    compile 'com.google.android.gms:play-services-wearable:5.0.77'
+    compile 'com.google.android.gms:play-services-wearable:8.1.0'
     compile 'com.google.android.support:wearable:+'
 }
 

--- a/wear/build.gradle
+++ b/wear/build.gradle
@@ -27,7 +27,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.google.android.gms:play-services-wearable:5.0.77'
+    compile 'com.google.android.gms:play-services-wearable:8.1.0'
     compile 'com.google.android.support:wearable:+'
 }
 


### PR DESCRIPTION
This library needs to be recompiled to be compatible with Google Play Services 8.1.

8.1 introduced some breaking changes to the API (some interfaces are now abstract classes instead, see [release notes](https://developers.google.com/android/guides/releases#september_2015)). The actual java code that uses the API mostly remains the same, but not the compiled bytecode (since it differs for abstract vs interface methods). Hence all that is required is to update the Google Play Services dependency version to the latest.

The following dependency combination causes a crash (see below), as a result of this breaking change.

``` groovy
compile 'fr.nicolaspomepuy.androidwearcrashreport:crashreport-mobile:0.4@aar'
compile 'com.google.android.gms:play-services-wearable:8.1.0'
```

```
java.lang.IncompatibleClassChangeError: The method 'void com.google.android.gms.common.api.GoogleApiClient.connect()' was expected to be of type interface but instead was found to be of type virtual (declaration of 'java.lang.reflect.ArtMethod' appears in /system/framework/core-libart.jar)
            at fr.nicolaspomepuy.androidwearcrashreport.mobile.CrashReport.<init>(CrashReport.java:48)
            at fr.nicolaspomepuy.androidwearcrashreport.mobile.CrashReport.getInstance(CrashReport.java:35)
```

By the same reasoning, this change will cause incompatibility with any other libraries that target a lower version. Though the only solution in the long run is for every library to bump its dependency version up to 8.1.
